### PR TITLE
Bug fix: Improve estimation of length and azi of ray within a grid cell

### DIFF
--- a/angmean.m
+++ b/angmean.m
@@ -1,0 +1,4 @@
+function [meanangle_rad] = angmean(angledata_rad)
+meanangle_rad = atan2(mean(sin(angledata_rad)),mean(cos(angledata_rad)));
+end
+


### PR DESCRIPTION
This removes an approximation that can result in apparent azimuthal 
anisotropy that apparently worsens at high latitudes.